### PR TITLE
Fix Datagrid Checkbox Multi Select

### DIFF
--- a/aggrid/projects/nggrids/src/datagrid/datagrid.ts
+++ b/aggrid/projects/nggrids/src/datagrid/datagrid.ts
@@ -616,7 +616,7 @@ export class DataGrid extends NGGridDirective {
 
         this.agGridElementRef.nativeElement.addEventListener('click', (e: any) => {
             if(e.target.parentNode && e.target.parentNode.classList &&
-                e.target.parentNode.classList.contains('ag-selection-checkbox')) {
+                e.target.parentNode.classList.contains('ag-checkbox-input-wrapper')) {
                 let t = e.target.parentNode;
                 while(t && !t.hasAttribute('row-index')) t = t.parentNode;
                 if(t) {


### PR DESCRIPTION
We experienced an issue with checkbox selection and multi select enabled where on init, trying to click on another checkbox to select a second record (besides the default first) wouldn't work because the this.selectionEvent property would be undefined and not correctly set in this code block. After clicking a different row, checkbox multi select would work again because the this.selectionEvent property would still have the value from the row click. This class name check on the target.parent in the handler triggered by the checkbox click seems to be the origin of the issue.