### PR TITLE
Fix row selection corruption during paging/lazy loading

### DIFF
--- a/aggrid/projects/nggrids/src/datagrid/datagrid.ts
+++ b/aggrid/projects/nggrids/src/datagrid/datagrid.ts
@@ -2362,6 +2362,11 @@ export class DataGrid extends NGGridDirective {
 		}
 
 
+		// Preserve selectionEvent across node selection changes so that a pending
+		// user click (waiting in the 250ms debounce) is not lost when a data-load
+		// callback triggers this method concurrently.
+		const savedSelectionEvent = this.selectionEvent;
+
 		for (const oldSelectedNode of oldSelectedNodes) {
 			if (!oldSelectedNode.group && selectedNodes.indexOf(oldSelectedNode) === -1) {
 				this.selectionEvent = null;
@@ -2376,6 +2381,13 @@ export class DataGrid extends NGGridDirective {
 				selectedNode.setSelected(true);
 				isSelectedRowIndexesChanged = true;
 			}
+		}
+
+		// Restore the pending user selection event if there was one.
+		// Without this, the race between data-load callbacks and the 250ms
+		// onSelectionChanged debounce causes user clicks to be silently dropped.
+		if (savedSelectionEvent) {
+			this.selectionEvent = savedSelectionEvent;
 		}
 
 		return isSelectedRowIndexesChanged;
@@ -3784,8 +3796,15 @@ export class DataGrid extends NGGridDirective {
 				this.requestSelectionPromises.push(requestSelectionPromise);
 				requestSelectionPromise.then(
 					() => {
-						if (this.requestSelectionPromises.shift() !== requestSelectionPromise) {
-							this.log.error('requestSelectionPromises out of sync');
+						// Remove this specific promise instead of blindly shifting the first one.
+						// Promises can resolve out of order under load (e.g. during paging),
+						// and shift() would remove the wrong entry, leaving orphaned promises
+						// that permanently block server-initiated selection changes.
+						const promiseIdx = this.requestSelectionPromises.indexOf(requestSelectionPromise);
+						if (promiseIdx !== -1) {
+							this.requestSelectionPromises.splice(promiseIdx, 1);
+						} else {
+							this.log.error('requestSelectionPromises: resolved promise not found in queue');
 						}
 						if (this.scrollToSelectionWhenSelectionReady) {
 							this.scrollToSelection();
@@ -3801,8 +3820,11 @@ export class DataGrid extends NGGridDirective {
 						//success
 					},
 					(serverRows) => {
-						if (this.requestSelectionPromises.shift() !== requestSelectionPromise) {
-							this.log.error('requestSelectionPromises out of sync');
+						const promiseIdx = this.requestSelectionPromises.indexOf(requestSelectionPromise);
+						if (promiseIdx !== -1) {
+							this.requestSelectionPromises.splice(promiseIdx, 1);
+						} else {
+							this.log.error('requestSelectionPromises: rejected promise not found in queue');
 						}
 						//canceled
 						if (typeof serverRows === 'string') {


### PR DESCRIPTION
## Summary

- **Fix race condition** where user clicks are silently dropped when clicking a row while the grid is fetching new records during lazy loading (paging with large foundsets)
- **Fix promise queue corruption** in `requestSelectionPromises` that permanently blocks server-initiated selection changes, making the grid unrecoverable

## Problem

Two bugs interact to cause permanent selection corruption in grids with lazy-loaded data (e.g. 150K+ records, 200-record pages):

### Bug 1: `selectionEvent` cleared by data-load callback

1. User clicks a row → `selectionEvent` is set, 250ms debounce starts
2. A page-load callback fires before the debounce → calls `selectedRowIndexesChanged()`
3. The server still has the **old** selection (user's click hasn't been sent yet)
4. `selectedRowIndexesChanged()` deselects the user's clicked row and sets `selectionEvent = null`
5. When the debounce fires, `selectionEvent` is null → user's click is lost

### Bug 2: `requestSelectionPromises` queue uses FIFO `shift()` but promises resolve out of order

When promise B resolves before promise A, `shift()` removes A instead of B, leaving orphaned entries. The `!this.requestSelectionPromises.length` guard then permanently blocks all server-initiated selection changes — the grid can never sync its selection again.

## Fix

1. **Save and restore `selectionEvent`** around the node selection loops in `selectedRowIndexesChanged()`, so data-load callbacks don't destroy a pending user click
2. **Replace `shift()` with `indexOf` + `splice`** to remove the specific resolved/rejected promise, preventing queue corruption from out-of-order resolution

## Test plan

- [ ] Grid with 150K+ records using lazy loading (server-side row model)
- [ ] Scroll to trigger page fetches, click rows during loading — selection should stick
- [ ] Rapid clicking during paging — no `requestSelectionPromises out of sync` errors in console
- [ ] Selection remains functional after extended use (no permanent corruption)
- [ ] Multi-select with Ctrl/Shift still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)